### PR TITLE
fix bug when calling ast_grep from lua

### DIFF
--- a/lua/telescope/_extensions/ast_grep.lua
+++ b/lua/telescope/_extensions/ast_grep.lua
@@ -149,6 +149,8 @@ end
 
 ---@param opts setup_opts
 M.ast_grep = function(opts)
+    opts = vim.tbl_deep_extend("force", setup_opts, opts or {})
+
     local command = opts.command or {
         is_linux and "ast-grep" or "sg",
         "--json=stream",
@@ -158,7 +160,6 @@ M.ast_grep = function(opts)
         return x ~= "-p" and x~= "--pattern"
     end, command)
 
-    opts = vim.tbl_deep_extend("force", setup_opts, opts or {})
     local search_dirs = opts.search_dirs
     local grep_open_files = opts.grep_open_files
     opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()


### PR DESCRIPTION
Key binding `ast_grep` currently results in `nil` access when executing

My binding:
```lua
local extensions = require('telescope').extensions

vim.keymap.set('n', '<leader>fast', extensions.ast_grep.ast_grep, {})
```
which is setup according to:

https://github.com/nvim-telescope/telescope.nvim?tab=readme-ov-file#accessing-pickers-from-extensions